### PR TITLE
allow the use of reusable buffer for large inputs to hash and MAC

### DIFF
--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
@@ -26,8 +26,8 @@ static int psa_spm_init_refence_counter = 0;
 
 /* maximal memoty allocation for reading large hash ort mac input buffers.
 the data will be read in chunks of size */
-#if !defined (MAX_DATA_CHUNK_SIZE)
-    #define MAX_DATA_CHUNK_SIZE 400
+#if !defined (MAX_DATA_CHUNK_SIZE_IN_BYTES)
+    #define MAX_DATA_CHUNK_SIZE_IN_BYTES 400
 #endif
 
 // ------------------------- Partition's Main Thread ---------------------------
@@ -148,7 +148,7 @@ static void psa_mac_operation(void)
 
                     uint8_t * input_buffer = NULL;
                     size_t data_remaining = msg.in_size[1];
-                    size_t allocation_size = MIN(data_remaining, MAX_DATA_CHUNK_SIZE);
+                    size_t allocation_size = MIN(data_remaining, MAX_DATA_CHUNK_SIZE_IN_BYTES);
                     size_t size_to_read = 0;
 
                     input_buffer = mbedtls_calloc(1, allocation_size);
@@ -159,11 +159,7 @@ static void psa_mac_operation(void)
 
                     while (data_remaining > 0)
                     {
-                        size_to_read = data_remaining;
-                        if (size_to_read > MAX_DATA_CHUNK_SIZE)
-                        {
-                            size_to_read = MAX_DATA_CHUNK_SIZE;
-                        }
+                        size_to_read = MIN(data_remaining, MAX_DATA_CHUNK_SIZE_IN_BYTES);
                         bytes_read = psa_read(msg.handle, 1, input_buffer,
                                               size_to_read);
 
@@ -317,7 +313,7 @@ static void psa_hash_operation(void)
                     uint8_t * input_buffer = NULL;
                     size_t data_remaining = msg.in_size[1];
                     size_t size_to_read = 0;
-                    size_t allocation_size = MIN(data_remaining, MAX_DATA_CHUNK_SIZE);
+                    size_t allocation_size = MIN(data_remaining, MAX_DATA_CHUNK_SIZE_IN_BYTES);
 
                     input_buffer = mbedtls_calloc(1, allocation_size);
                     if (input_buffer == NULL) {
@@ -327,11 +323,7 @@ static void psa_hash_operation(void)
 
                     while (data_remaining > 0)
                     {
-                        size_to_read = data_remaining;
-                        if (size_to_read > MAX_DATA_CHUNK_SIZE)
-                        {
-                            size_to_read = MAX_DATA_CHUNK_SIZE;
-                        }
+                        size_to_read = MIN(data_remaining, MAX_DATA_CHUNK_SIZE_IN_BYTES);
                         bytes_read = psa_read(msg.handle, 1, input_buffer,
                                               size_to_read);
 

--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
@@ -145,7 +145,6 @@ static void psa_mac_operation(void)
                     size_t data_remaining = msg.in_size[1];
                     size_t allocation_size = data_remaining;
                     size_t size_to_read = 0;
-                    psa_status_t failure_status = PSA_SUCCESS;
                     
                     if (allocation_size > MAX_DATA_CHUNK_SIZE)
                     {
@@ -176,19 +175,14 @@ static void psa_mac_operation(void)
                                                 input_buffer,
                                                 bytes_read);
                         
-                        // return first error encountered in case of error.
-                        if ((status != PSA_SUCCESS) && 
-                            (failure_status == PSA_SUCCESS) )
+                        // stop on error 
+                        if (status != PSA_SUCCESS)
                         {
-                            failure_status = status;
+                            break;
                         }
                         data_remaining = data_remaining - bytes_read;
                     }
-                    // return first error encountered in case of error.
-                    if (failure_status != PSA_SUCCESS)
-                    {
-                        status = failure_status;
-                    }
+                    
                     mbedtls_free(input_buffer);
 
                     break;
@@ -324,20 +318,16 @@ static void psa_hash_operation(void)
                     size_t data_remaining = msg.in_size[1];
                     size_t size_to_read = 0;
                     size_t allocation_size = data_remaining;
-                    psa_status_t failure_status = PSA_SUCCESS;
 
                     if (allocation_size > MAX_DATA_CHUNK_SIZE)
                     {
                         allocation_size = MAX_DATA_CHUNK_SIZE;
                     }
 
-                    if (input_buffer == NULL)
-                    {
-                        input_buffer = mbedtls_calloc(1, allocation_size);
-                        if (input_buffer == NULL) {
-                            status = PSA_ERROR_INSUFFICIENT_MEMORY;
-                            break;
-                        }
+                    input_buffer = mbedtls_calloc(1, allocation_size);
+                    if (input_buffer == NULL) {
+                        status = PSA_ERROR_INSUFFICIENT_MEMORY;
+                        break;
                     }
 
                     while (data_remaining > 0)
@@ -358,19 +348,14 @@ static void psa_hash_operation(void)
                                                 input_buffer,
                                                 bytes_read);
 
-                        // return first error encountered in case of error.
-                        if ((status != PSA_SUCCESS) && 
-                            (failure_status == PSA_SUCCESS) )
+                        // stop on error 
+                        if (status != PSA_SUCCESS)
                         {
-                            failure_status = status;
+                            break;
                         }
                         data_remaining = data_remaining - bytes_read;
                     }
-                    // return first error encountered in case of error.
-                    if (failure_status != PSA_SUCCESS)
-                    {
-                        status = failure_status;
-                    }
+
                     mbedtls_free(input_buffer);
 
                     break;

--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
@@ -19,6 +19,12 @@
 // ------------------------- Globals ---------------------------
 static int psa_spm_init_refence_counter = 0;
 
+/* maximal memoty allocation for reading large hash ort mac input buffers.
+the data will be read in chunks of size */
+#if !defined (MAX_DATA_CHUNK_SIZE)
+    #define MAX_DATA_CHUNK_SIZE 400
+#endif
+
 // ------------------------- Partition's Main Thread ---------------------------
 static void psa_crypto_init_operation(void)
 {
@@ -134,24 +140,57 @@ static void psa_mac_operation(void)
                 }
 
                 case PSA_MAC_UPDATE: {
-                    uint8_t *input_ptr = mbedtls_calloc(1, msg.in_size[1]);
-                    if (input_ptr == NULL) {
+
+                    uint8_t * input_buffer = NULL;
+                    size_t data_remaining = msg.in_size[1];
+                    size_t allocation_size = data_remaining;
+                    size_t size_to_read = 0;
+                    psa_status_t failure_status = PSA_SUCCESS;
+                    
+                    if (allocation_size > MAX_DATA_CHUNK_SIZE)
+                    {
+                        allocation_size = MAX_DATA_CHUNK_SIZE;
+                    }
+
+                    input_buffer = mbedtls_calloc(1, allocation_size);
+                    if (input_buffer == NULL) {
                         status = PSA_ERROR_INSUFFICIENT_MEMORY;
                         break;
                     }
 
-                    bytes_read = psa_read(msg.handle, 1, input_ptr,
-                                          msg.in_size[1]);
+                    while (data_remaining > 0)
+                    {
+                        size_to_read = data_remaining;
+                        if (size_to_read > MAX_DATA_CHUNK_SIZE)
+                        {
+                            size_to_read = MAX_DATA_CHUNK_SIZE;
+                        }
+                        bytes_read = psa_read(msg.handle, 1, input_buffer,
+                                              size_to_read);
 
-                    if (bytes_read != msg.in_size[1]) {
-                        SPM_PANIC("SPM read length mismatch");
+                        if (bytes_read != size_to_read) {
+                            SPM_PANIC("SPM read length mismatch");
+                        }
+
+                        status = psa_mac_update(msg.rhandle,
+                                                input_buffer,
+                                                bytes_read);
+                        
+                        // return first error encountered in case of error.
+                        if ((status != PSA_SUCCESS) && 
+                            (failure_status == PSA_SUCCESS) )
+                        {
+                            failure_status = status;
+                        }
+                        data_remaining = data_remaining - bytes_read;
                     }
+                    // return first error encountered in case of error.
+                    if (failure_status != PSA_SUCCESS)
+                    {
+                        status = failure_status;
+                    }
+                    mbedtls_free(input_buffer);
 
-                    status = psa_mac_update(msg.rhandle,
-                                            input_ptr,
-                                            msg.in_size[1]);
-
-                    mbedtls_free(input_ptr);
                     break;
                 }
 
@@ -281,23 +320,59 @@ static void psa_hash_operation(void)
                 }
 
                 case PSA_HASH_UPDATE: {
-                    uint8_t *input_ptr = mbedtls_calloc(1, msg.in_size[1]);
-                    if (input_ptr == NULL) {
-                        status = PSA_ERROR_INSUFFICIENT_MEMORY;
-                        break;
+                    uint8_t * input_buffer = NULL;
+                    size_t data_remaining = msg.in_size[1];
+                    size_t size_to_read = 0;
+                    size_t allocation_size = data_remaining;
+                    psa_status_t failure_status = PSA_SUCCESS;
+
+                    if (allocation_size > MAX_DATA_CHUNK_SIZE)
+                    {
+                        allocation_size = MAX_DATA_CHUNK_SIZE;
                     }
 
-                    bytes_read = psa_read(msg.handle, 1, input_ptr,
-                                          msg.in_size[1]);
-
-                    if (bytes_read != msg.in_size[1]) {
-                        SPM_PANIC("SPM read length mismatch");
+                    if (input_buffer == NULL)
+                    {
+                        input_buffer = mbedtls_calloc(1, allocation_size);
+                        if (input_buffer == NULL) {
+                            status = PSA_ERROR_INSUFFICIENT_MEMORY;
+                            break;
+                        }
                     }
 
-                    status = psa_hash_update(msg.rhandle,
-                                             input_ptr,
-                                             msg.in_size[1]);
-                    mbedtls_free(input_ptr);
+                    while (data_remaining > 0)
+                    {
+                        size_to_read = data_remaining;
+                        if (size_to_read > MAX_DATA_CHUNK_SIZE)
+                        {
+                            size_to_read = MAX_DATA_CHUNK_SIZE;
+                        }
+                        bytes_read = psa_read(msg.handle, 1, input_buffer,
+                                              size_to_read);
+
+                        if (bytes_read != size_to_read) {
+                            SPM_PANIC("SPM read length mismatch");
+                        }
+
+                        status = psa_hash_update(msg.rhandle,
+                                                input_buffer,
+                                                bytes_read);
+
+                        // return first error encountered in case of error.
+                        if ((status != PSA_SUCCESS) && 
+                            (failure_status == PSA_SUCCESS) )
+                        {
+                            failure_status = status;
+                        }
+                        data_remaining = data_remaining - bytes_read;
+                    }
+                    // return first error encountered in case of error.
+                    if (failure_status != PSA_SUCCESS)
+                    {
+                        status = failure_status;
+                    }
+                    mbedtls_free(input_buffer);
+
                     break;
                 }
 

--- a/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
+++ b/components/TARGET_PSA/services/crypto/COMPONENT_SPE/psa_crypto_partition.c
@@ -16,6 +16,11 @@
 #define mbedtls_calloc calloc
 #define mbedtls_free   free
 #endif
+
+#if !defined(MIN)
+#define MIN( a, b ) ( ( ( a ) < ( b ) ) ? ( a ) : ( b ) )
+#endif
+
 // ------------------------- Globals ---------------------------
 static int psa_spm_init_refence_counter = 0;
 
@@ -143,13 +148,8 @@ static void psa_mac_operation(void)
 
                     uint8_t * input_buffer = NULL;
                     size_t data_remaining = msg.in_size[1];
-                    size_t allocation_size = data_remaining;
+                    size_t allocation_size = MIN(data_remaining, MAX_DATA_CHUNK_SIZE);
                     size_t size_to_read = 0;
-                    
-                    if (allocation_size > MAX_DATA_CHUNK_SIZE)
-                    {
-                        allocation_size = MAX_DATA_CHUNK_SIZE;
-                    }
 
                     input_buffer = mbedtls_calloc(1, allocation_size);
                     if (input_buffer == NULL) {
@@ -317,12 +317,7 @@ static void psa_hash_operation(void)
                     uint8_t * input_buffer = NULL;
                     size_t data_remaining = msg.in_size[1];
                     size_t size_to_read = 0;
-                    size_t allocation_size = data_remaining;
-
-                    if (allocation_size > MAX_DATA_CHUNK_SIZE)
-                    {
-                        allocation_size = MAX_DATA_CHUNK_SIZE;
-                    }
+                    size_t allocation_size = MIN(data_remaining, MAX_DATA_CHUNK_SIZE);
 
                     input_buffer = mbedtls_calloc(1, allocation_size);
                     if (input_buffer == NULL) {


### PR DESCRIPTION
This should allow the processing of large data without large memory allocation on the secure side.

### Description


raised for internal review of memory optimizations.

note there is a design consideration that came up. Alex asked me to use a re-usable buffer (lazy allocation on first use, freed on Psa_crypto_free) which has some upsides, but also has a significant downside:
1. in case of small input buffers you can allocate (and keep allocated) a lot more memory than required.

I couldn't think of a way to mitigate this while keeping the re-usable buffer (if we allocate each time, we can alloc MAX(sizeNeeded, max buffer size) and effectively never over-allocate).

different workloads will yield different performance in these cases so I'm not sure which is better before we know the actual use.



### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ X ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!-- 
    Optional
    Request additional reviewers with @username
-->

